### PR TITLE
Add link to unofficial Gentoo ebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ poppler-qt5 and python-poppler-qt5 are optional.
 
 ### Available packages
 * [AUR](https://aur.archlinux.org/packages/lector-git/)
+* [Gentoo (unofficial)](https://bitbucket.org/szymonsz/gen2-overlay/src/master/app-text/lector/)
 
 ## Translations
 1. There is a `SAMPLE.ts` file in `resources/translations`. Open it in `Qt Linguist`.


### PR DESCRIPTION
I have prepared an unofficial Gentoo ebuild. Link how to use my ebuild's repository is in the root of the linked repo. Currently, there are two versions available *0.2* (from GH releases) and *9999* (live git ebuild).

If you will not want to add it to the README it is fine. I was looking for a tool like yours, so I thought I will help.
