### PR TITLE
Added HiDPI support

### DIFF
--- a/lector/__main__.py
+++ b/lector/__main__.py
@@ -1073,11 +1073,15 @@ class MainUI(QtWidgets.QMainWindow, mainwindow.Ui_MainWindow):
 
 
 def main():
+    # before we create the app, we hijack QT_AUTO_SCREEN_SCALE_FACTOR to force device scaling to be accurate
+    os.environ["QT_AUTO_SCREEN_SCALE_FACTOR"] = "1"
+    # Make icons sharp in HiDPI screen
+    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps, True)
+    QtWidgets.QApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling, True)
+
     app = QtWidgets.QApplication(sys.argv)
     app.setApplicationName('Lector')  # This is needed for QStandardPaths
                                       # and my own hubris
-    # Make icons sharp in HiDPI screen
-    app.setAttribute(QtCore.Qt.AA_UseHighDpiPixmaps, True)
 
     # Internationalization support
     translator = QtCore.QTranslator()


### PR DESCRIPTION
Here's a before/after on my 4K monitor with 1.5x device scaling setup (click through, the absolute sizes are more important):

![before](https://user-images.githubusercontent.com/1606892/75620666-9fd56200-5b59-11ea-9725-807bad65b4c6.png)
![after](https://user-images.githubusercontent.com/1606892/75620668-a1068f00-5b59-11ea-96cc-b7ee8062536b.png)

In particular, before, the icons are way too small to use on this monitor. Thanks!