### PR TITLE
Fix incorrect parameter types

### DIFF
--- a/lector/models.py
+++ b/lector/models.py
@@ -125,7 +125,7 @@ class TableProxyModel(QtCore.QSortFilterProxyModel):
 
                 if not file_exists:
                     return pie_chart.pixmapper(
-                        -1, None, None, QtCore.Qt.SizeHintRole + 10)
+                        -1, None, -1, QtCore.Qt.SizeHintRole + 10)
 
                 if position_percent:
                     return_pixmap = pie_chart.pixmapper(


### PR DESCRIPTION
I opened some e-books from a removable disk. Next time when I start the Lector program, it corrupted since the removable disk is not attached.
The pie_chart.pixmapper expects a integer for the parameter consider_read_at while a None is given, which caused the program corrupted.