### PR TITLE
Bug fixed when self.adjisted_size is float

### DIFF
--- a/lector/toolbars.py
+++ b/lector/toolbars.py
@@ -516,7 +516,7 @@ class FixedComboBox(QtWidgets.QComboBox):
         return self.minimumSizeHint()
 
     def minimumSizeHint(self):
-        return QtCore.QSize(self.adjusted_size, 32)
+        return QtCore.QSize(int(self.adjusted_size), 32)
 
     def wheelEvent(self, QWheelEvent):
         # Disable mouse wheel scrolling in the ComboBox
@@ -532,7 +532,7 @@ class FixedLineEdit(QtWidgets.QLineEdit):
         return self.minimumSizeHint()
 
     def minimumSizeHint(self):
-        return QtCore.QSize(self.adjusted_size, 32)
+        return QtCore.QSize(int(self.adjusted_size), 32)
 
     def keyReleaseEvent(self, event):
         if event.key() == QtCore.Qt.Key_Escape:


### PR DESCRIPTION
Bug fixed when `self.adjisted_size` is float and `QSize` expects an integer.

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/lector/toolbars.py", line 514, in sizeHint
    return QtCore.QSize(self.adjusted_size, 22)
TypeError: arguments did not match any overloaded call:
  QSize(): too many arguments
  QSize(int, int): argument 1 has unexpected type 'float'
  QSize(QSize): argument 1 has unexpected type 'float'
fish: Job 1, 'lector' terminated by signal SIGABRT (Abort)
```